### PR TITLE
feat: Implement Phase 1 SQL Frontend for IglooEngine

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+// src/lib.rs
+pub mod sql_frontend;

--- a/src/sql_frontend/converter.rs
+++ b/src/sql_frontend/converter.rs
@@ -1,0 +1,313 @@
+// src/sql_frontend/converter.rs
+use crate::sql_frontend::logical_plan::{Expression, LiteralValue, LogicalPlan, Operator};
+use sqlparser::ast::{
+    BinaryOperator as SqlBinaryOperator, Expr as SqlExpr, Ident, ObjectName, Query as SqlQuery,
+    SelectItem as SqlSelectItem, SetExpr as SqlSetExpr, Statement as SqlStatement,
+    TableFactor as SqlTableFactor, TableWithJoins as SqlTableWithJoins, Value as SqlValue,
+};
+
+// Helper to convert sqlparser::ast::Value to logical_plan::LiteralValue
+fn sql_value_to_logical_literal(sql_value: &SqlValue) -> Result<LiteralValue, String> {
+    match sql_value {
+        SqlValue::Number(s, _) => Ok(LiteralValue::Number(s.clone())),
+        SqlValue::SingleQuotedString(s) => Ok(LiteralValue::String(s.clone())),
+        SqlValue::NationalStringLiteral(s) => Ok(LiteralValue::String(s.clone())),
+        SqlValue::HexStringLiteral(s) => Ok(LiteralValue::String(s.clone())),
+        SqlValue::DoubleQuotedString(s) => Ok(LiteralValue::String(s.clone())),
+        SqlValue::Boolean(b) => Ok(LiteralValue::Boolean(*b)),
+        SqlValue::Null => Ok(LiteralValue::Null),
+        // SqlValue::Interval {..} | SqlValue::Placeholder(_) | SqlValue::UnQuotedString(_) etc.
+        _ => Err(format!("Unsupported SQL value: {:?}", sql_value)),
+    }
+}
+
+// Helper to convert sqlparser::ast::BinaryOperator to logical_plan::Operator
+fn sql_operator_to_logical_operator(op: &SqlBinaryOperator) -> Result<Operator, String> {
+    match op {
+        SqlBinaryOperator::Eq => Ok(Operator::Eq),
+        SqlBinaryOperator::NotEq => Ok(Operator::NotEq),
+        SqlBinaryOperator::Lt => Ok(Operator::Lt),
+        SqlBinaryOperator::LtEq => Ok(Operator::LtEq),
+        SqlBinaryOperator::Gt => Ok(Operator::Gt),
+        SqlBinaryOperator::GtEq => Ok(Operator::GtEq),
+        SqlBinaryOperator::And => Ok(Operator::And),
+        SqlBinaryOperator::Or => Ok(Operator::Or),
+        _ => Err(format!("Unsupported SQL operator: {:?}", op)),
+    }
+}
+
+// Helper to convert sqlparser::ast::Expr to logical_plan::Expression
+// This function will be recursive for nested expressions.
+fn sql_expr_to_logical_expr(sql_expr: &SqlExpr) -> Result<Expression, String> {
+    match sql_expr {
+        SqlExpr::Identifier(ident) => Ok(Expression::Column(ident.value.clone())),
+        SqlExpr::CompoundIdentifier(idents) => {
+            // For simplicity, join idents with "." e.g., "table.column"
+            // This might need more sophisticated handling for schemas, etc. later
+            Ok(Expression::Column(
+                idents.iter().map(|i| i.value.clone()).collect::<Vec<String>>().join("."),
+            ))
+        }
+        SqlExpr::Value(value) => {
+            let literal_val = sql_value_to_logical_literal(value)?;
+            Ok(Expression::Literal(literal_val))
+        }
+        SqlExpr::BinaryOp { left, op, right } => {
+            let logical_left = Box::new(sql_expr_to_logical_expr(left)?);
+            let logical_op = sql_operator_to_logical_operator(op)?;
+            let logical_right = Box::new(sql_expr_to_logical_expr(right)?);
+            Ok(Expression::BinaryExpr {
+                left: logical_left,
+                op: logical_op,
+                right: logical_right,
+            })
+        }
+        // SqlExpr::IsNull(_) | SqlExpr::IsNotNull(_) | SqlExpr::InList {..} etc.
+        _ => Err(format!("Unsupported SQL expression: {:?}", sql_expr)),
+    }
+}
+
+fn sql_select_item_to_logical_expression(item: &SqlSelectItem) -> Result<Expression, String> {
+    match item {
+        SqlSelectItem::UnnamedExpr(expr) => sql_expr_to_logical_expr(expr),
+        SqlSelectItem::ExprWithAlias { expr, alias } => {
+            let logical_expr = sql_expr_to_logical_expr(expr)?;
+            Ok(Expression::Alias {
+                expr: Box::new(logical_expr),
+                alias: alias.value.clone(),
+            })
+        }
+        SqlSelectItem::QualifiedWildcard(object_name, _) => {
+            // For `table.*` or `schema.table.*`
+            // Represent as a special kind of column or handle in Projection directly
+            // For now, map to a string like "table.*"
+            Ok(Expression::Column(format!("{}.*", object_name.0.iter().map(|i| i.value.clone()).collect::<Vec<_>>().join("."))))
+        }
+        SqlSelectItem::Wildcard(_) => {
+            Ok(Expression::Wildcard) // Represents `*`
+        }
+    }
+}
+
+
+/// Converts a parsed SQL AST Statement into a LogicalPlan.
+/// Currently supports simple SELECT ... FROM ... WHERE queries.
+pub fn ast_to_logical_plan(statement: &SqlStatement) -> Result<LogicalPlan, String> {
+    match statement {
+        SqlStatement::Query(query) => {
+            let SqlQuery { body, .. } = &**query; // Dereference Box<Query>
+            match body {
+                SqlSetExpr::Select(select_statement) => {
+                    let from_clause = &select_statement.from;
+                    let selection_clause = &select_statement.selection; // This is the WHERE clause
+                    let projection_list = &select_statement.projection;
+
+                    // 1. Process FROM clause -> LogicalPlan::Scan
+                    //    For now, assume a single table and no joins.
+                    if from_clause.len() != 1 {
+                        return Err(format!(
+                            "Expected exactly one table in FROM clause, found {}",
+                            from_clause.len()
+                        ));
+                    }
+                    let table_with_joins: &SqlTableWithJoins = &from_clause[0];
+                    if !table_with_joins.joins.is_empty() {
+                        return Err("Joins are not supported yet".to_string());
+                    }
+                    let table_name_parts: Vec<String> = match &table_with_joins.relation {
+                        SqlTableFactor::Table { name, .. } => {
+                            // name is ObjectName { 0: Vec<Ident> }
+                            name.0.iter().map(|ident| ident.value.clone()).collect()
+                        }
+                        _ => return Err("Unsupported table factor in FROM clause. Expected simple table name.".to_string()),
+                    };
+                    let table_name = table_name_parts.join("."); // e.g., "users" or "schema.users"
+
+                    // Determine columns for Scan. If projection is wildcard, columns is None.
+                    // Otherwise, it's Some(vec![col_names...]) if we want to pass this info to Scan.
+                    // For now, let's simplify: if any projection item is a wildcard, columns for Scan is None.
+                    // This is a simplification; actual columns might be derived from non-wildcard projection items.
+                    let mut scan_columns: Option<Vec<String>> = None;
+                    // let mut is_wildcard_projection = false; // This variable is not used
+                    let mut projected_expressions = Vec::new();
+
+                    for item in projection_list {
+                        let logical_expr = sql_select_item_to_logical_expression(item)?;
+                        if logical_expr == Expression::Wildcard {
+                            // is_wildcard_projection = true; // This variable is not used
+                        }
+                        // If item is `table.*`, it's also a form of wildcard for that table.
+                        // Our current Expression::Column("table.*") will be passed to projection.
+                        projected_expressions.push(logical_expr);
+                    }
+
+                    // If `*` is present (or table.*), Scan node gets `columns = None` indicating all columns.
+                    // The Projection node will also contain `Expression::Wildcard` or `Expression::Column("table.*")`.
+                    // If no `*`, we could potentially list the explicitly named columns for the Scan node.
+                    // For now, let's keep it None and let Projection handle it. This can be an optimization later.
+                    scan_columns = None;
+
+
+                    let mut current_plan = LogicalPlan::Scan {
+                        table_name,
+                        columns: scan_columns,
+                    };
+
+                    // 2. Process WHERE clause -> LogicalPlan::Filter
+                    if let Some(predicate_expr) = selection_clause {
+                        let logical_predicate = sql_expr_to_logical_expr(predicate_expr)?;
+                        current_plan = LogicalPlan::Filter {
+                            input: Box::new(current_plan),
+                            predicate: logical_predicate,
+                        };
+                    }
+
+                    // 3. Process SELECT list -> LogicalPlan::Projection
+                    //    `projected_expressions` already built above.
+                    current_plan = LogicalPlan::Projection {
+                        input: Box::new(current_plan),
+                        expressions: projected_expressions,
+                    };
+
+                    Ok(current_plan)
+                }
+                _ => Err("Unsupported query type in SET expression. Expected SELECT.".to_string()),
+            }
+        }
+        _ => Err(format!(
+            "Unsupported SQL statement type: {:?}. Only Query statements are supported.",
+            statement
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sql_frontend::parser::parse_sql; // Assuming parser is accessible
+
+    fn parse_and_convert(sql: &str) -> Result<LogicalPlan, String> {
+        let statements = parse_sql(sql).map_err(|e| format!("Parse error: {}", e))?;
+        if statements.is_empty() {
+            return Err("No SQL statements found".to_string());
+        }
+        if statements.len() > 1 {
+            return Err("Expected single SQL statement for conversion".to_string());
+        }
+        ast_to_logical_plan(&statements[0])
+    }
+
+    #[test]
+    fn test_simple_select_from_where() {
+        let sql = "SELECT id, name FROM users WHERE id = 1";
+        let plan = parse_and_convert(sql).unwrap();
+
+        // Expected: Projection { expressions: [Column("id"), Column("name")], input: Filter { predicate: (Column("id") Eq Literal(Number("1"))), input: Scan { table_name: "users", columns: None } } }
+        if let LogicalPlan::Projection { expressions, input } = plan {
+            assert_eq!(expressions.len(), 2);
+            assert_eq!(expressions[0], Expression::Column("id".to_string()));
+            assert_eq!(expressions[1], Expression::Column("name".to_string()));
+
+            if let LogicalPlan::Filter { predicate, input: filter_input } = *input {
+                // Predicate: id = 1
+                if let Expression::BinaryExpr {left, op, right} = predicate {
+                    assert_eq!(*left, Expression::Column("id".to_string()));
+                    assert_eq!(op, Operator::Eq);
+                    assert_eq!(*right, Expression::Literal(LiteralValue::Number("1".to_string())));
+                } else {
+                    panic!("Expected BinaryExpr for predicate");
+                }
+
+                if let LogicalPlan::Scan { table_name, columns } = *filter_input {
+                    assert_eq!(table_name, "users");
+                    assert_eq!(columns, None); // Defaulting to None for now
+                } else {
+                    panic!("Expected Scan for filter input");
+                }
+            } else {
+                panic!("Expected Filter node");
+            }
+        } else {
+            panic!("Expected Projection node at the top");
+        }
+    }
+
+    #[test]
+    fn test_select_star_from() {
+        let sql = "SELECT * FROM customers";
+        let plan = parse_and_convert(sql).unwrap();
+        // Expected: Projection { expressions: [Wildcard], input: Scan { table_name: "customers", columns: None } }
+        if let LogicalPlan::Projection { expressions, input } = plan {
+            assert_eq!(expressions.len(), 1);
+            assert_eq!(expressions[0], Expression::Wildcard);
+            if let LogicalPlan::Scan { table_name, columns } = *input {
+                assert_eq!(table_name, "customers");
+                assert_eq!(columns, None);
+            } else {
+                panic!("Expected Scan node for Projection input");
+            }
+        } else {
+            panic!("Expected Projection node for SELECT *");
+        }
+    }
+
+    #[test]
+    fn test_select_with_alias() {
+        let sql = "SELECT name AS customer_name FROM customers";
+        let plan = parse_and_convert(sql).unwrap();
+        // Expected: Projection { expressions: [Alias { expr: Column("name"), alias: "customer_name" }], input: Scan { table_name: "customers", columns: None } }
+        if let LogicalPlan::Projection { expressions, input: _ } = plan { // Corrected to _input
+            assert_eq!(expressions.len(), 1);
+            assert_eq!(expressions[0], Expression::Alias { expr: Box::new(Expression::Column("name".to_string())), alias: "customer_name".to_string() });
+            // Check input is Scan (can be added if necessary)
+        } else {
+            panic!("Expected Projection node for SELECT with alias");
+        }
+    }
+
+    #[test]
+    fn test_unsupported_statement() {
+        let sql = "INSERT INTO users (id, name) VALUES (1, 'Alice')";
+        let result = parse_and_convert(sql);
+        assert!(result.is_err());
+        // We need to adjust the expected error message to match the actual sqlparser output for Insert
+        // The exact formatting of the unsupported statement might be verbose.
+        // For now, let's check if it starts with "Unsupported SQL statement type: Insert"
+        if let Err(e) = result {
+            assert!(e.starts_with("Unsupported SQL statement type: Insert"), "Error message was: {}", e);
+        } else {
+            panic!("Expected error for unsupported statement");
+        }
+    }
+
+    #[test]
+    fn test_compound_identifier_in_projection() {
+        let sql = "SELECT users.name FROM users";
+        let plan = parse_and_convert(sql).unwrap();
+        if let LogicalPlan::Projection { expressions, .. } = plan {
+            assert_eq!(expressions.len(), 1);
+            assert_eq!(expressions[0], Expression::Column("users.name".to_string()));
+        } else {
+            panic!("Expected Projection node");
+        }
+    }
+
+    #[test]
+    fn test_compound_identifier_in_filter() {
+        let sql = "SELECT name FROM users WHERE users.age > 25";
+        let plan = parse_and_convert(sql).unwrap();
+        if let LogicalPlan::Projection { input, .. } = plan {
+            if let LogicalPlan::Filter { predicate, .. } = *input {
+                if let Expression::BinaryExpr { left, ..} = predicate {
+                    assert_eq!(*left, Expression::Column("users.age".to_string()));
+                } else {
+                    panic!("Expected BinaryExpr for predicate");
+                }
+            } else {
+                panic!("Expected Filter node");
+            }
+        } else {
+            panic!("Expected Projection node");
+        }
+    }
+}

--- a/src/sql_frontend/logical_plan.rs
+++ b/src/sql_frontend/logical_plan.rs
@@ -1,0 +1,78 @@
+// src/sql_frontend/logical_plan.rs
+
+/// Represents a literal value in an expression.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LiteralValue {
+    String(String),
+    Number(String), // Using String for numbers as per plan, for simplicity with sqlparser output
+    Boolean(bool),
+    Null,
+}
+
+/// Represents a binary operator in an expression.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Operator {
+    Eq,         // =
+    NotEq,      // <> or !=
+    Lt,         // <
+    LtEq,       // <=
+    Gt,         // >
+    GtEq,       // >=
+    And,        // AND
+    Or,         // OR
+    // Add more operators as needed, e.g., Plus, Minus, Multiply, Divide for arithmetic
+}
+
+/// Represents an expression in a logical plan.
+/// These are the building blocks for predicates and projections.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expression {
+    /// A named column, e.g., "users.id" or "id".
+    Column(String),
+    /// A literal value, e.g., 'hello', 123, TRUE.
+    Literal(LiteralValue),
+    /// A binary expression, e.g., "age > 25".
+    BinaryExpr {
+        left: Box<Expression>,
+        op: Operator,
+        right: Box<Expression>,
+    },
+    /// Represents an aliased expression, e.g., `SELECT count(id) AS total_users`.
+    /// For now, the `alias` will just be the string name. The `expr` is the expression being aliased.
+    /// This might be more relevant for projections.
+    Alias {
+        expr: Box<Expression>,
+        alias: String,
+    },
+    /// Represents a wildcard selection, e.g., `*` in `SELECT *`.
+    Wildcard,
+}
+
+/// Represents a logical plan for a query.
+/// This is a tree-like structure that defines the operations to be performed.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LogicalPlan {
+    /// Projects a set of expressions.
+    Projection {
+        input: Box<LogicalPlan>,
+        expressions: Vec<Expression>, // These are the columns/expressions to output
+    },
+    /// Filters rows based on a predicate.
+    Filter {
+        input: Box<LogicalPlan>,
+        predicate: Expression,
+    },
+    /// Scans a table, optionally with a specific list of columns.
+    /// If `columns` is `None`, it implies all columns (e.g., for `SELECT *`).
+    Scan {
+        table_name: String,
+        /// Specific columns to scan from the table.
+        /// `None` means all columns. For a `SELECT *` this would be `None`.
+        /// For `SELECT a, b`, this might be `Some(vec!["a".to_string(), "b".to_string()])`
+        /// if the scan operation itself can optimize by fetching only these.
+        /// However, the `Projection` node is the primary place where output columns are defined.
+        /// Keeping it here allows for potential pushdowns later.
+        columns: Option<Vec<String>>,
+    },
+    // Other potential nodes for future: Aggregate, Sort, Join, Limit, etc.
+}

--- a/src/sql_frontend/mod.rs
+++ b/src/sql_frontend/mod.rs
@@ -1,0 +1,46 @@
+// src/sql_frontend/mod.rs
+pub mod converter;
+pub mod logical_plan;
+pub mod parser;
+
+// Re-export key types for easier access if desired, e.g.:
+// pub use logical_plan::{LogicalPlan, Expression, LiteralValue, Operator};
+// pub use parser::parse_sql;
+// pub use converter::ast_to_logical_plan;
+// For now, users can use sql_frontend::logical_plan::LogicalPlan, etc.
+
+use logical_plan::LogicalPlan; // Added for the facade function's return type
+
+/// Parses a SQL string and converts it into a LogicalPlan.
+///
+/// This function serves as the main entry point for the SQL frontend.
+/// It encapsulates the parsing of the SQL string into an AST
+/// and then converts that AST into the engine's LogicalPlan representation.
+///
+/// # Arguments
+/// * `sql` - A string slice representing the SQL query.
+///
+/// # Returns
+/// A `Result` containing the `LogicalPlan` if successful,
+/// or a `String` error message if parsing or conversion fails.
+pub fn sql_to_logical_plan(sql: &str) -> Result<LogicalPlan, String> {
+    let statements =
+        parser::parse_sql(sql).map_err(|e| format!("SQL Parsing Error: {}", e))?;
+
+    if statements.is_empty() {
+        return Err("No SQL statements provided.".to_string());
+    }
+
+    // Assuming, for now, that we process only the first statement.
+    // Production systems might handle multiple statements or specific kinds of statements.
+    if statements.len() > 1 {
+        // Or, iterate through them and return Vec<LogicalPlan>
+        // For now, let's stick to the common case of a single query.
+        eprintln!("Warning: Multiple SQL statements found, only the first one will be processed.");
+    }
+
+    converter::ast_to_logical_plan(&statements[0])
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/sql_frontend/parser.rs
+++ b/src/sql_frontend/parser.rs
@@ -1,0 +1,56 @@
+// src/sql_frontend/parser.rs
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::{Parser, ParserError};
+use sqlparser::ast::Statement;
+
+/// Parses a SQL string into a vector of AST Statements.
+///
+/// # Arguments
+/// * `sql` - A string slice representing the SQL query.
+///
+/// # Returns
+/// A `Result` containing a `Vec<Statement>` if parsing is successful,
+/// or a `ParserError` if an error occurs.
+pub fn parse_sql(sql: &str) -> Result<Vec<Statement>, ParserError> {
+    let dialect = GenericDialect {}; // Or AnsiDialect {}, depending on desired compatibility
+    Parser::parse_sql(&dialect, sql)
+}
+
+// Basic tests for the parser
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simple_select() {
+        let sql = "SELECT id, name FROM users WHERE id = 1";
+        let result = parse_sql(sql);
+        assert!(result.is_ok());
+        let statements = result.unwrap();
+        assert_eq!(statements.len(), 1);
+        // Further assertions can be made on the statement structure if needed
+    }
+
+    #[test]
+    fn test_invalid_sql() {
+        let sql = "SELECT FROM WHERE id = 1"; // Invalid SQL
+        let result = parse_sql(sql);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_sql_empty_query() {
+        let sql = "";
+        let result = parse_sql(sql);
+        assert!(result.is_ok()); // sqlparser-rs returns Ok(vec![]) for empty string
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_parse_sql_multiple_statements() {
+         let sql = "SELECT * FROM table1; SELECT * FROM table2;";
+         let result = parse_sql(sql);
+         assert!(result.is_ok());
+         assert_eq!(result.unwrap().len(), 2);
+    }
+}

--- a/src/sql_frontend/tests.rs
+++ b/src/sql_frontend/tests.rs
@@ -1,0 +1,143 @@
+// src/sql_frontend/tests.rs
+use crate::sql_frontend::sql_to_logical_plan;
+use crate::sql_frontend::logical_plan::{Expression, LiteralValue, LogicalPlan, Operator};
+
+#[test]
+fn test_e2e_select_name_age_from_users_where_age_gt_25() {
+    let sql = "SELECT name, age FROM users WHERE age > 25";
+    let plan_result = sql_to_logical_plan(sql);
+    assert!(plan_result.is_ok(), "sql_to_logical_plan failed: {:?}", plan_result.err());
+
+    let plan = plan_result.unwrap();
+
+    // Expected:
+    // Projection {
+    //   expressions: [Column("name"), Column("age")],
+    //   input: Filter {
+    //     predicate: (Column("age") Gt Literal(Number("25"))),
+    //     input: Scan { table_name: "users", columns: None }
+    //   }
+    // }
+    if let LogicalPlan::Projection { expressions, input } = plan {
+        assert_eq!(expressions.len(), 2);
+        assert_eq!(expressions[0], Expression::Column("name".to_string()));
+        assert_eq!(expressions[1], Expression::Column("age".to_string()));
+
+        if let LogicalPlan::Filter { predicate, input: filter_input } = *input {
+            if let Expression::BinaryExpr {left, op, right} = predicate {
+                assert_eq!(*left, Expression::Column("age".to_string()));
+                assert_eq!(op, Operator::Gt);
+                // Assuming sqlparser gives "25" as a string for Number
+                assert_eq!(*right, Expression::Literal(LiteralValue::Number("25".to_string())));
+            } else {
+                panic!("Expected BinaryExpr for predicate, got {:?}", predicate);
+            }
+
+            if let LogicalPlan::Scan { table_name, columns } = *filter_input {
+                assert_eq!(table_name, "users");
+                assert_eq!(columns, None, "Scan columns should be None for this query structure");
+            } else {
+                panic!("Expected Scan for filter input, got {:?}", *filter_input);
+            }
+        } else {
+            panic!("Expected Filter node as input to Projection, got {:?}", *input);
+        }
+    } else {
+        panic!("Expected Projection node at the top, got {:?}", plan);
+    }
+}
+
+#[test]
+fn test_e2e_select_star_from_table() {
+    let sql = "SELECT * FROM orders";
+    let plan_result = sql_to_logical_plan(sql);
+    assert!(plan_result.is_ok(), "sql_to_logical_plan failed: {:?}", plan_result.err());
+    let plan = plan_result.unwrap();
+
+    // Expected:
+    // Projection {
+    //   expressions: [Wildcard],
+    //   input: Scan { table_name: "orders", columns: None }
+    // }
+    if let LogicalPlan::Projection { expressions, input } = plan {
+        assert_eq!(expressions.len(), 1);
+        assert_eq!(expressions[0], Expression::Wildcard);
+
+        if let LogicalPlan::Scan { table_name, columns } = *input {
+            assert_eq!(table_name, "orders");
+            assert_eq!(columns, None, "Scan columns should be None for SELECT *");
+        } else {
+            panic!("Expected Scan node as input to Projection for SELECT *, got {:?}", *input);
+        }
+    } else {
+        panic!("Expected Projection node for SELECT *, got {:?}", plan);
+    }
+}
+
+#[test]
+fn test_e2e_select_columns_from_table_no_where() {
+    let sql = "SELECT product_id, quantity FROM order_items";
+    let plan_result = sql_to_logical_plan(sql);
+    assert!(plan_result.is_ok(), "sql_to_logical_plan failed: {:?}", plan_result.err());
+    let plan = plan_result.unwrap();
+
+    // Expected:
+    // Projection {
+    //   expressions: [Column("product_id"), Column("quantity")],
+    //   input: Scan { table_name: "order_items", columns: None }
+    // }
+    if let LogicalPlan::Projection { expressions, input } = plan {
+        assert_eq!(expressions.len(), 2);
+        assert_eq!(expressions[0], Expression::Column("product_id".to_string()));
+        assert_eq!(expressions[1], Expression::Column("quantity".to_string()));
+
+        if let LogicalPlan::Scan { table_name, columns } = *input {
+            assert_eq!(table_name, "order_items");
+            assert_eq!(columns, None, "Scan columns should be None");
+        } else {
+            panic!("Expected Scan node as input to Projection, got {:?}", *input);
+        }
+    } else {
+        panic!("Expected Projection node, got {:?}", plan);
+    }
+}
+
+#[test]
+fn test_e2e_select_with_alias_and_filter() {
+    let sql = "SELECT name AS cust_name, email FROM customers WHERE country = 'USA'";
+    let plan_result = sql_to_logical_plan(sql);
+    assert!(plan_result.is_ok(), "sql_to_logical_plan failed: {:?}", plan_result.err());
+    let plan = plan_result.unwrap();
+
+    // Expected: Projection -> Filter -> Scan
+    if let LogicalPlan::Projection { expressions, input } = plan {
+        assert_eq!(expressions.len(), 2);
+        assert_eq!(expressions[0], Expression::Alias {
+            expr: Box::new(Expression::Column("name".to_string())),
+            alias: "cust_name".to_string(),
+        });
+        assert_eq!(expressions[1], Expression::Column("email".to_string()));
+
+        if let LogicalPlan::Filter { predicate, input: filter_input } = *input {
+            // Predicate: country = 'USA'
+            if let Expression::BinaryExpr {left, op, right} = predicate {
+                assert_eq!(*left, Expression::Column("country".to_string()));
+                assert_eq!(op, Operator::Eq);
+                assert_eq!(*right, Expression::Literal(LiteralValue::String("USA".to_string())));
+            } else {
+                panic!("Expected BinaryExpr for predicate, got {:?}", predicate);
+            }
+
+            if let LogicalPlan::Scan { table_name, columns } = *filter_input {
+                assert_eq!(table_name, "customers");
+                assert_eq!(columns, None);
+            } else {
+                panic!("Expected Scan for filter input, got {:?}", *filter_input);
+            }
+        } else {
+            panic!("Expected Filter node, got {:?}", *input);
+        }
+    } else {
+        panic!("Expected Projection node, got {:?}", plan);
+    }
+}


### PR DESCRIPTION
This commit introduces the initial SQL frontend component for the IglooEngine. The frontend is responsible for parsing a SQL query string and converting it into a LogicalPlan, an internal representation used by the engine.

Key features implemented:
- SQL Parser Integration:
    - Uses the `sqlparser-rs` crate to parse SQL strings into an Abstract Syntax Tree (AST).
    - Includes a `parser::parse_sql` function.
- Logical Plan Definition:
    - Defines core data structures (`LogicalPlan`, `Expression`, `LiteralValue`, `Operator`) in `logical_plan.rs` to represent queries. Variants include `Scan`, `Filter`, and `Projection`.
- AST to Logical Plan Conversion:
    - Implements `converter::ast_to_logical_plan` to transform the `sqlparser-rs` AST into the engine's `LogicalPlan`.
    - Supports `SELECT ... FROM ... WHERE ...` queries, including column selection, aliases, wildcards, and basic predicate expressions.
- Facade Function:
    - Provides a main entry point `sql_frontend::sql_to_logical_plan(sql: &str)` that orchestrates parsing and conversion.
- Testing:
    - Adds unit tests for the parser and converter components.
    - Includes integration tests for the `sql_to_logical_plan` facade, covering various query types, specifically verifying the query "SELECT name, age FROM users WHERE age > 25" as per Phase 1 requirements.

Note: I was blocked from running tests by pre-existing Rust compiler version incompatibilities within the project's dependencies. The implemented code is syntactically valid and structured to meet the defined tasks.